### PR TITLE
Add RawNode nodes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 3.1.0
+=============
+
+- [fix] Added RawNode node and make source blocks emit lists of RawNode instead of TextNode. This prevents escaping characters in formats like HTML. Raw blocks now use a list of RawNode as well.
+
 Version 3.0.2
 =============
 

--- a/e2e_tests/output/test_source_blocks.yaml
+++ b/e2e_tests/output/test_source_blocks.yaml
@@ -28,25 +28,25 @@ data:
       classes: []
       code:
       - data:
-          type: text
+          type: raw
           value: This is all literal.
       - data:
-          type: text
+          type: raw
           value: ''
       - data:
-          type: text
+          type: raw
           value: == This is not a header
       - data:
-          type: text
+          type: raw
           value: ''
       - data:
-          type: text
+          type: raw
           value: '[These are not attributes]'
       - data:
-          type: text
+          type: raw
           value: ''
       - data:
-          type: text
+          type: raw
           value: Some quotes ""
       highlights: []
       kwargs: {}
@@ -82,49 +82,49 @@ data:
       classes: []
       code:
       - data:
-          type: text
+          type: raw
           value: 'def header_anchor(text, level):'
       - data:
-          type: text
+          type: raw
           value: '    """'
       - data:
-          type: text
+          type: raw
           value: '    Return a sanitised anchor for a header.'
       - data:
-          type: text
+          type: raw
           value: '    """'
       - data:
-          type: text
+          type: raw
           value: ''
       - data:
-          type: text
+          type: raw
           value: '    # Everything lowercase'
       - data:
-          type: text
+          type: raw
           value: '    sanitised_text = text.lower()'
       - data:
-          type: text
+          type: raw
           value: ''
       - data:
-          type: text
+          type: raw
           value: '    # Get only letters, numbers, dashes, spaces, and dots'
       - data:
-          type: text
+          type: raw
           value: '    sanitised_text = "".join(re.findall("[a-z0-9-\\. ]+", sanitised_text))'
       - data:
-          type: text
+          type: raw
           value: ''
       - data:
-          type: text
+          type: raw
           value: '    # Remove multiple spaces'
       - data:
-          type: text
+          type: raw
           value: '    sanitised_text = "-".join(sanitised_text.split())'
       - data:
-          type: text
+          type: raw
           value: ''
       - data:
-          type: text
+          type: raw
           value: '    return sanitised_text'
       highlights: []
       kwargs: {}
@@ -176,16 +176,16 @@ data:
       classes: []
       code:
       - data:
-          type: text
+          type: raw
           value: 'def header_anchor(text, level):'
       - data:
-          type: text
+          type: raw
           value: '    return "h{}-{}-{}".format('
       - data:
-          type: text
+          type: raw
           value: '        level, quote(text.lower())[:20], str(id(text))[:8]'
       - data:
-          type: text
+          type: raw
           value: '    )  # pragma: no cover'
       highlights: []
       kwargs: {}

--- a/e2e_tests/parser/test_source_blocks.yaml
+++ b/e2e_tests/parser/test_source_blocks.yaml
@@ -28,25 +28,25 @@ data:
       classes: []
       code:
       - data:
-          type: text
+          type: raw
           value: This is all literal.
       - data:
-          type: text
+          type: raw
           value: ''
       - data:
-          type: text
+          type: raw
           value: == This is not a header
       - data:
-          type: text
+          type: raw
           value: ''
       - data:
-          type: text
+          type: raw
           value: '[These are not attributes]'
       - data:
-          type: text
+          type: raw
           value: ''
       - data:
-          type: text
+          type: raw
           value: Some quotes ""
       highlights: []
       kwargs: {}
@@ -82,49 +82,49 @@ data:
       classes: []
       code:
       - data:
-          type: text
+          type: raw
           value: 'def header_anchor(text, level):'
       - data:
-          type: text
+          type: raw
           value: '    """'
       - data:
-          type: text
+          type: raw
           value: '    Return a sanitised anchor for a header.'
       - data:
-          type: text
+          type: raw
           value: '    """'
       - data:
-          type: text
+          type: raw
           value: ''
       - data:
-          type: text
+          type: raw
           value: '    # Everything lowercase'
       - data:
-          type: text
+          type: raw
           value: '    sanitised_text = text.lower()'
       - data:
-          type: text
+          type: raw
           value: ''
       - data:
-          type: text
+          type: raw
           value: '    # Get only letters, numbers, dashes, spaces, and dots'
       - data:
-          type: text
+          type: raw
           value: '    sanitised_text = "".join(re.findall("[a-z0-9-\\. ]+", sanitised_text))'
       - data:
-          type: text
+          type: raw
           value: ''
       - data:
-          type: text
+          type: raw
           value: '    # Remove multiple spaces'
       - data:
-          type: text
+          type: raw
           value: '    sanitised_text = "-".join(sanitised_text.split())'
       - data:
-          type: text
+          type: raw
           value: ''
       - data:
-          type: text
+          type: raw
           value: '    return sanitised_text'
       highlights: []
       kwargs: {}
@@ -176,16 +176,16 @@ data:
       classes: []
       code:
       - data:
-          type: text
+          type: raw
           value: 'def header_anchor(text, level):'
       - data:
-          type: text
+          type: raw
           value: '    return "h{}-{}-{}".format('
       - data:
-          type: text
+          type: raw
           value: '        level, quote(text.lower())[:20], str(id(text))[:8]'
       - data:
-          type: text
+          type: raw
           value: '    )  # pragma: no cover'
       highlights: []
       kwargs: {}

--- a/mau/nodes/inline.py
+++ b/mau/nodes/inline.py
@@ -20,6 +20,15 @@ class TextNode(ValueNode):
     node_type = "text"
 
 
+class RawNode(ValueNode):
+    """This contains plain text but the content
+    should be treated as raw data and left untouched.
+    E.g. it shouldn't be escaped.
+    """
+
+    node_type = "raw"
+
+
 class VerbatimNode(ValueNode):
     """This node contains verbatim text."""
 

--- a/mau/parsers/main_parser.py
+++ b/mau/parsers/main_parser.py
@@ -7,7 +7,7 @@ from mau.lexers.base_lexer import TokenTypes as BLTokenTypes
 from mau.lexers.main_lexer import MainLexer
 from mau.lexers.main_lexer import TokenTypes as MLTokenTypes
 from mau.nodes.footnotes import CommandFootnotesNode, FootnotesEntryNode
-from mau.nodes.inline import ListItemNode, TextNode
+from mau.nodes.inline import ListItemNode, RawNode, TextNode
 from mau.nodes.page import (
     BlockNode,
     CommandTocNode,
@@ -780,9 +780,9 @@ class MainParser(BaseParser):
         if engine == "raw":
             # Engine "raw" doesn't process the content,
             # so we just pass it untouched in the form of
-            # a TextNode per line.
-            content = [TextNode(line) for line in content]
-            secondary_content = [TextNode(line) for line in secondary_content]
+            # a RawNode per line.
+            content = [RawNode(line) for line in content]
+            secondary_content = [RawNode(line) for line in secondary_content]
         elif engine in ["default", "mau"]:
             # Both engines parse content and secondary content
             # using a new parser but the default one should merge
@@ -957,7 +957,7 @@ class MainParser(BaseParser):
             if line.startswith(r"\::#"):
                 line = line[1:]
 
-            textlines.append(TextNode(line))
+            textlines.append(RawNode(line))
 
         self._save(
             SourceNode(

--- a/mau/visitors/base_visitor.py
+++ b/mau/visitors/base_visitor.py
@@ -66,6 +66,14 @@ class BaseVisitor:
 
     # Inline nodes
 
+    def _visit_raw(self, node, *args, **kwargs):
+        return {
+            "data": {
+                "type": node.node_type,
+                "value": node.value,
+            },
+        }
+
     def _visit_text(self, node, *args, **kwargs):
         return {
             "data": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "mau"
-version = "3.0.2"
+version = "3.1.0"
 description = "A lightweight template-driven markup language"
 authors = [{name = "Leonardo Giordani", email = "giordani.leonardo@gmail.com"}]
 license = {file = "LICENSE"}

--- a/tests/nodes/test_inline.py
+++ b/tests/nodes/test_inline.py
@@ -7,6 +7,7 @@ from mau.nodes.inline import (
     SentenceNode,
     StyleNode,
     TextNode,
+    RawNode,
     VerbatimNode,
     WordNode,
 )
@@ -26,6 +27,14 @@ def test_text_node():
     assert node.value == "somevalue"
     assert node.node_type == "text"
     assert node == TextNode("somevalue")
+
+
+def test_raw_node():
+    node = RawNode("somevalue")
+
+    assert node.value == "somevalue"
+    assert node.node_type == "raw"
+    assert node == RawNode("somevalue")
 
 
 def test_verbatim_node():

--- a/tests/parsers/main_parser/test_block_attributes.py
+++ b/tests/parsers/main_parser/test_block_attributes.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 from mau.lexers.main_lexer import MainLexer
-from mau.nodes.inline import SentenceNode, TextNode
+from mau.nodes.inline import SentenceNode, TextNode, RawNode
 from mau.nodes.page import BlockNode, HeaderNode, ParagraphNode
 from mau.parsers.base_parser import ParserError
 from mau.parsers.main_parser import MainParser
@@ -254,12 +254,12 @@ def test_block_raw_engine():
         BlockNode(
             blocktype="block",
             content=[
-                TextNode("Raw content"),
-                TextNode("on multiple lines"),
+                RawNode("Raw content"),
+                RawNode("on multiple lines"),
             ],
             secondary_content=[
-                TextNode("Secondary content"),
-                TextNode("on multiple lines as well"),
+                RawNode("Secondary content"),
+                RawNode("on multiple lines as well"),
             ],
             classes=[],
             title=None,

--- a/tests/parsers/main_parser/test_block_source.py
+++ b/tests/parsers/main_parser/test_block_source.py
@@ -1,6 +1,6 @@
 import pytest
 from mau.lexers.main_lexer import MainLexer
-from mau.nodes.inline import SentenceNode, TextNode
+from mau.nodes.inline import SentenceNode, TextNode, RawNode
 from mau.nodes.source import CalloutNode, CalloutsEntryNode, SourceNode
 from mau.parsers.base_parser import ParserError
 from mau.parsers.main_parser import MainParser
@@ -51,8 +51,8 @@ def test_source_contains_mau():
     assert runner(source).nodes == [
         SourceNode(
             code=[
-                TextNode("// A comment"),
-                TextNode("::toc:"),
+                RawNode("// A comment"),
+                RawNode("::toc:"),
             ],
         ),
     ]
@@ -69,7 +69,7 @@ def test_source_removes_escape_from_directive_like_text():
     assert runner(source).nodes == [
         SourceNode(
             code=[
-                TextNode("::#looks like a directive"),
+                RawNode("::#looks like a directive"),
             ],
         ),
     ]
@@ -88,9 +88,9 @@ def test_source_with_code():
     assert runner(source).nodes == [
         SourceNode(
             code=[
-                TextNode("import os"),
-                TextNode(""),
-                TextNode('print(os.environ["HOME"])'),
+                RawNode("import os"),
+                RawNode(""),
+                RawNode('print(os.environ["HOME"])'),
             ],
         ),
     ]
@@ -111,9 +111,9 @@ def test_source_explicit_engine():
             blocktype="myblock",
             language="somelang",
             code=[
-                TextNode("import os"),
-                TextNode(""),
-                TextNode('print(os.environ["HOME"])'),
+                RawNode("import os"),
+                RawNode(""),
+                RawNode('print(os.environ["HOME"])'),
             ],
         ),
     ]
@@ -134,9 +134,9 @@ def test_source_with_title():
         SourceNode(
             language="somelang",
             code=[
-                TextNode("import os"),
-                TextNode(""),
-                TextNode('print(os.environ["HOME"])'),
+                RawNode("import os"),
+                RawNode(""),
+                RawNode('print(os.environ["HOME"])'),
             ],
             title=SentenceNode([TextNode("Title")]),
         ),
@@ -155,8 +155,8 @@ def test_source_ignores_mau_syntax():
     assert runner(source).nodes == [
         SourceNode(
             code=[
-                TextNode(":answer:42"),
-                TextNode("The answer is {answer}"),
+                RawNode(":answer:42"),
+                RawNode("The answer is {answer}"),
             ],
         ),
     ]
@@ -173,7 +173,7 @@ def test_source_respects_spaces_and_indentation():
     assert runner(source).nodes == [
         SourceNode(
             code=[
-                TextNode("  //    This is a comment"),
+                RawNode("  //    This is a comment"),
             ],
         ),
     ]
@@ -196,10 +196,10 @@ def test_source_callouts():
         SourceNode(
             language="somelang",
             code=[
-                TextNode("import sys"),
-                TextNode("import os"),
-                TextNode(""),
-                TextNode('print(os.environ["HOME"])'),
+                RawNode("import sys"),
+                RawNode("import os"),
+                RawNode(""),
+                RawNode('print(os.environ["HOME"])'),
             ],
             markers=[CalloutNode(1, "imp"), CalloutNode(3, "env")],
             callouts=[
@@ -227,10 +227,10 @@ def test_source_callouts_possible_clash():
         SourceNode(
             language="somelang",
             code=[
-                TextNode("import sys"),
-                TextNode("import: os"),
-                TextNode(""),
-                TextNode('print(os.environ["HOME"])'),
+                RawNode("import sys"),
+                RawNode("import: os"),
+                RawNode(""),
+                RawNode('print(os.environ["HOME"])'),
             ],
             markers=[CalloutNode(1, "imp"), CalloutNode(3, "env")],
             callouts=[
@@ -254,8 +254,8 @@ def test_source_callouts_one_single_marker_is_skipped():
         SourceNode(
             language="somelang",
             code=[
-                TextNode("def something:"),
-                TextNode('    print("AAA")'),
+                RawNode("def something:"),
+                RawNode('    print("AAA")'),
             ],
             markers=[],
             callouts=[],
@@ -278,10 +278,10 @@ def test_source_callouts_custom_delimiter():
         SourceNode(
             language="somelang",
             code=[
-                TextNode("import sys"),
-                TextNode("import os"),
-                TextNode(""),
-                TextNode('print(os.environ["HOME"])'),
+                RawNode("import sys"),
+                RawNode("import os"),
+                RawNode(""),
+                RawNode('print(os.environ["HOME"])'),
             ],
             markers=[CalloutNode(1, "imp"), CalloutNode(3, "env")],
         ),
@@ -323,10 +323,10 @@ def test_source_highlights():
         SourceNode(
             language="somelang",
             code=[
-                TextNode("import sys"),
-                TextNode("import os"),
-                TextNode(""),
-                TextNode('print(os.environ["HOME"])'),
+                RawNode("import sys"),
+                RawNode("import os"),
+                RawNode(""),
+                RawNode('print(os.environ["HOME"])'),
             ],
             highlights=[1, 3],
         ),
@@ -348,10 +348,10 @@ def test_source_highlights_custom_marker():
         SourceNode(
             language="somelang",
             code=[
-                TextNode("import sys"),
-                TextNode("import os"),
-                TextNode(""),
-                TextNode('print(os.environ["HOME"])'),
+                RawNode("import sys"),
+                RawNode("import os"),
+                RawNode(""),
+                RawNode('print(os.environ["HOME"])'),
             ],
             highlights=[1, 3],
         ),

--- a/tests/visitors/base_visitor/test_inline_nodes.py
+++ b/tests/visitors/base_visitor/test_inline_nodes.py
@@ -8,6 +8,7 @@ from mau.nodes.inline import (
     MacroNode,
     SentenceNode,
     StyleNode,
+    RawNode,
     TextNode,
     VerbatimNode,
 )
@@ -31,6 +32,21 @@ def test_unknown_node():
 
     with pytest.raises(VisitorError):
         visitor.visit(node)
+
+
+def test_raw_node():
+    visitor = BaseVisitor()
+
+    node = RawNode("Just some text.")
+
+    result = visitor.visit(node)
+
+    assert result == {
+        "data": {
+            "type": "raw",
+            "value": "Just some text.",
+        }
+    }
 
 
 def test_text_node():


### PR DESCRIPTION
This adds a new type of node, `RawNode`, and makes source blocks and raw blocks use a list of those instead of using `TextNode`. This makes it possible to avoid escaping them in formats like HTML where text nodes have to be escaped.